### PR TITLE
Add "last updated" alert to landing page

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,11 +3,14 @@
 import { PersonSearch } from '@/components/PersonSearch';
 import { AnimatedCounter } from '@/components/AnimatedCounter';
 import { Card, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useTranslation } from '@/lib/i18n-context';
+import { AlertTriangle } from 'lucide-react';
+import Link from 'next/link';
 import { useState, useEffect } from 'react';
 
 export default function Home() {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const [stats, setStats] = useState<{ totalPersons: number } | null>(null);
 
   useEffect(() => {
@@ -28,6 +31,25 @@ export default function Home() {
   return (
     <div className="fixed inset-0 top-20 md:top-16 flex flex-col items-center justify-center bg-background px-4 sm:px-6 lg:px-8 pb-16">
       <div className="text-center mb-12 lg:mb-16">
+        <Alert
+          variant="destructive"
+          className="mx-auto mb-8 max-w-xl w-fit border-destructive/30 bg-destructive/5 text-left"
+        >
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            <span className="text-foreground/80">
+              {t('home.lastUpdatedPrefix')}{' '}
+              <Link
+                href={`/${locale}/sources`}
+                className="font-medium text-destructive underline underline-offset-2 hover:text-destructive/80"
+              >
+                {t('home.lastUpdatedDate')}
+              </Link>
+              {'. '}
+            </span>
+            <span className="font-bold text-destructive">{t('home.genocideContinues')}</span>
+          </AlertDescription>
+        </Alert>
         <h1 className="mb-6 text-3xl font-bold tracking-tight sm:text-4xl lg:text-5xl min-[1440px]:text-7xl text-foreground">
           {t('home.title')}
         </h1>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -17,7 +17,10 @@
     "subtitleEvent": "الإبادة الجماعية",
     "searchPlaceholder": "البحث بالاسم أو رقم الهوية...",
     "searchExplainer": "ابحث عن شخص للمساهمة بمعلومات ناقصة",
-    "contributeText": "ساعد في تخليد ذكراهم"
+    "contributeText": "ساعد في تخليد ذكراهم",
+    "lastUpdatedPrefix": "آخر تحديث للمصادر في",
+    "lastUpdatedDate": "31 يوليو 2025",
+    "genocideContinues": "الإبادة الجماعية مستمرة."
   },
   "about": {
     "title": "عن المشروع",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,10 @@
     "subtitleEvent": "Ministry of Health",
     "searchPlaceholder": "Search by name or ID...",
     "searchExplainer": "Search for a person to contribute missing information",
-    "contributeText": "Help remember their lives"
+    "contributeText": "Help remember their lives",
+    "lastUpdatedPrefix": "The sources were last updated",
+    "lastUpdatedDate": "July 31, 2025",
+    "genocideContinues": "The genocide continues."
   },
   "about": {
     "title": "About",


### PR DESCRIPTION
## Summary

The underlying source data has not been refreshed in some time. This PR adds a clear, persistent notice on the landing page so visitors understand the figures are not current — and points them to where the data comes from.

## What changed

- **New alert banner** above the hero heading on the home page ([src/app/[locale]/page.tsx](src/app/[locale]/page.tsx)), using the existing `Alert` component in its `destructive` variant with a warning icon. It reads:

  > ⚠️ The sources were last updated **July 31, 2025**. **The genocide continues.**

  The closing sentence is bold/red for emphasis; the lead-in is muted.

- **Date links to Sources** — "July 31, 2025" is a locale-aware `next/link` to `/{locale}/sources`, so readers can see the provenance and last-refresh of the figures.

- **Bilingual copy** — the new strings are added as i18n keys (`lastUpdatedPrefix`, `lastUpdatedDate`, `genocideContinues`) in both [en.json](src/locales/en.json) and [ar.json](src/locales/ar.json), keeping the banner fully translated in English and Arabic.

## Notes

- The date is currently static text. When new source data eventually lands, update `lastUpdatedDate` in the two locale files. (Happy to wire it up to derive automatically from the latest source's uploaded date in a follow-up if preferred.)

## Verification

- `/en` and `/ar` render the banner with all copy and no console/build errors.
- The date renders as `<a href="/{locale}/sources">` and navigates to the Sources page.
- Reviewed visually in the browser at localhost:3000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)